### PR TITLE
Fix macOS build

### DIFF
--- a/src/zarchivereader.cpp
+++ b/src/zarchivereader.cpp
@@ -234,7 +234,7 @@ uint64_t ZArchiveReader::ReadFromFile(ZArchiveNodeHandle nodeHandle, uint64_t of
 	{
 		uint64_t blockIdx = rawReadOffset / _ZARCHIVE::COMPRESSED_BLOCK_SIZE;
 		uint32_t blockOffset = (uint32_t)(rawReadOffset % _ZARCHIVE::COMPRESSED_BLOCK_SIZE);
-		uint32_t stepSize = std::min(remainingBytes, _ZARCHIVE::COMPRESSED_BLOCK_SIZE - blockOffset);
+		uint32_t stepSize = std::min((uint32_t)remainingBytes, (uint32_t)(_ZARCHIVE::COMPRESSED_BLOCK_SIZE - blockOffset));
 		CacheBlock* block = GetCachedBlock(blockIdx);
 		if (!block)
 			return 0;


### PR DESCRIPTION
Continuing work on https://github.com/NiceneNerd/ukmm/issues/7. This resolves the following error when compiling with clang/gcc on macOS:
```
The following warnings were emitted during compilation:

warning: src/zarchivereader.cpp:237:23: error: no matching function for call to 'min'
warning:                 uint32_t stepSize = std::min(remainingBytes, _ZARCHIVE::COMPRESSED_BLOCK_SIZE - blockOffset);
warning:                                     ^~~~~~~~
warning: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__algorithm/min.h:39:1: note: candidate template ignored: deduced conflicting types for parameter '_Tp' ('unsigned long long' vs. 'unsigned long')
warning: min(const _Tp& __a, const _Tp& __b)
warning: ^
warning: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__algorithm/min.h:50:1: note: candidate template ignored: could not match 'initializer_list<type-parameter-0-0>' against 'unsigned long long'
warning: min(initializer_list<_Tp> __t, _Compare __comp)
warning: ^
warning: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__algorithm/min.h:59:1: note: candidate function template not viable: requires single argument '__t', but 2 arguments were provided
warning: min(initializer_list<_Tp> __t)
warning: ^
warning: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__algorithm/min.h:30:1: note: candidate function template not viable: requires 3 arguments, but 2 were provided
warning: min(const _Tp& __a, const _Tp& __b, _Compare __comp)
warning: ^
warning: 1 error generated.
```

The compiler seems unable to determine the correct min template to use, as it requires both arguments to have the same size. I cast both of them and compilation succeeded.

Along with https://github.com/NiceneNerd/ryml/pull/1, ukmm can compile on Intel/AS macOS with clang (gcc still gives me linker errors), but panics at runtime. I was able to get the GUI running with an old commit 3389c61deca1c91fbcd85b7b9dc8653f821662d4, so I'll try later to bisect and see what's the last working commit for Mac